### PR TITLE
plugin: fixes to keep Cordova 8 and 7 support

### DIFF
--- a/install/hooks/android/after-prepare-build-node-assets-lists.js
+++ b/install/hooks/android/after-prepare-build-node-assets-lists.js
@@ -26,7 +26,7 @@ function enumFolder(folderPath) {
 
 function createFileAndFolderLists(context, callback) {
   try {
-    var cordovaLib = require('cordova-lib');
+    var cordovaLib = context.requireCordovaModule('cordova-lib');
     var platformAPI = cordovaLib.cordova_platforms.getPlatformApi('android');
     var nodeJsProjectRoot = 'www/nodejs-project';
     // The Android application's assets path will be the parent of the application's www folder.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "license": "MIT",
   "dependencies": {
     "nodejs-mobile-gyp": "^0.3.1",
-    "tar.gz2": "^1.0.0"
+    "tar.gz2": "^1.0.0",
+    "xcode": "^2.0.0"
   },
   "homepage": "https://code.janeasystems.com/nodejs-mobile",
   "repository": {


### PR DESCRIPTION
Adds xcode dependency to use with require.
Reverts cordova-lib to requireCordovaModule, since it's a cordova
module.